### PR TITLE
fix: remove spec.paused experiment

### DIFF
--- a/charts/all/chatqna-gaudi-backend/templates/chatqna-gaudi-backend-server-buildconfig.yaml
+++ b/charts/all/chatqna-gaudi-backend/templates/chatqna-gaudi-backend-server-buildconfig.yaml
@@ -13,7 +13,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/chatqna-ui-server/templates/chatqna-gaudi-ui-server-buildconfig.yaml
+++ b/charts/all/chatqna-ui-server/templates/chatqna-gaudi-ui-server-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/dataprep/templates/dataprep-buildconfig.yaml
+++ b/charts/all/dataprep/templates/dataprep-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/embedding/templates/embedding-buildconfig.yaml
+++ b/charts/all/embedding/templates/embedding-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/llm-server-for-gaudi/templates/llm-buildconfig.yaml
+++ b/charts/all/llm-server-for-gaudi/templates/llm-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/reranking/templates/reranking-buildconfig.yaml
+++ b/charts/all/reranking/templates/reranking-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/retriever/templates/retriever-buildconfig.yaml
+++ b/charts/all/retriever/templates/retriever-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly

--- a/charts/all/tei-embedding-service/templates/tei-embedding-service-buildconfig.yaml
+++ b/charts/all/tei-embedding-service/templates/tei-embedding-service-buildconfig.yaml
@@ -11,7 +11,6 @@ spec:
   failedBuildsHistoryLimit: 5
   successfulBuildsHistoryLimit: 5
   nodeSelector: null
-  paused: true
   postCommit: {}
   resources: {}
   runPolicy: SerialLatestOnly


### PR DESCRIPTION
This shouldn't make any difference because it is not actively parsed by OCP but might cause issues in the long run (it was an experiment that I left out).