### PR TITLE
Fixed incorrect keyword in rhods-operator-gaudi-addons Chart.yaml

### DIFF
--- a/charts/all/rhods-operator-gaudi-addons/Chart.yaml
+++ b/charts/all/rhods-operator-gaudi-addons/Chart.yaml
@@ -1,4 +1,4 @@
-oapiVersion: v2
+apiVersion: v2
 description: A Helm chart for RHODS (Red Hat OpenShift Data Science) deployment of Gaudi2-related addons
 keywords:
 - rhods-operator-gaudi-addons


### PR DESCRIPTION
Chart.yaml contained `oapiVersion` instead of `apiVersion` in it. This PR fixes that